### PR TITLE
Рефакторинг проверки на вызов подкоманд в команде.

### DIFF
--- a/bot/commands.py
+++ b/bot/commands.py
@@ -12,29 +12,9 @@ bot = commands.Bot(
 	intents=intents
 )
 
-def is_me():
-	def checkSubcommandPresence(ctx) -> bool:
-		# ctx.command.invoke_without_command #! это всё можно было бы сделать одной строкой, если бы данная штука работала.
-		current_content = ctx.message.content
-		current_content = current_content.removeprefix(ctx.prefix)
-		base_content_len = len(current_content)
-		current_main_command_aliases = list(ctx.command.aliases) + [ctx.command.name]
-		for command_alias in current_main_command_aliases:
-			current_content = current_content.removeprefix(command_alias + " ")
-			if len(current_content) != base_content_len:
-				break
-		for command in ctx.command.commands:
-			for alias in list(command.aliases) + [command.name]:
-				if current_content.startswith(alias):
-					return True
-		return False
-		# TODO вывод ошибки.
-	return commands.check(checkSubcommandPresence)
-
-@bot.group(aliases=["logs"])
-@is_me()
+@bot.group(aliases=["logs"], invoke_without_command=True)
 async def log(ctx: commands.Context) -> None:
-	pass
+	await ctx.send("Убедитесь, что вы указали пункт меню.")
 
 @log.command(aliases=["1", "cr"])
 async def create(


### PR DESCRIPTION
Используется [`invoke_without_command`](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.ext.commands.Group.invoke_without_command), который при значении True указывает, что проверки checks, парсинг аргументов и тело функции-группы будет выполняться только в том случае, если не была вызвана подкоманда.

---

Также можно использовать [как здесь](https://discordpy.readthedocs.io/en/stable/faq.html#how-do-i-make-a-subcommand):
```python
@bot.group(aliases=["logs"])
async def log(ctx: commands.Context) -> None:
	if ctx.invoked_subcommand is None:
		await ctx.send("Убедитесь, что вы указали пункт меню.")
```
В таком случае проверки, парсинг и тело функции-группы будет выполняться сразу, а уже после вызванная подкоманда (если она есть) (если до этого не была вызвана ошибка).